### PR TITLE
fix: backport upstream security fixes for multiple glances CVEs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+glances (4.3.1+dfsg-1deepin1) unstable; urgency=high
+
+  * Fix CVE-2026-30928: Unauthenticated Configuration Secrets Exposure
+  * Fix CVE-2026-32609: Incomplete Secrets Redaction in /api/4/args
+    endpoint
+  * Fix CVE-2026-32596: Unauthenticated Web Server Exposure
+  * Fix CVE-2026-32608: Mustache Template Command Injection
+  * Fix CVE-2026-32610: CORS Wildcard with Credentials
+  * Fix CVE-2026-32632: DNS Rebinding Protection
+  * Fix CVE-2026-32633: Serverslist API Exposes Downstream Credentials
+  * Fix CVE-2026-32634: Central Browser Credential Leak
+  * Fix CVE-2026-33533: XML-RPC CORS Information Disclosure
+  * Fix CVE-2026-33641: Config Backtick Command Execution
+
+ -- lichenggang <lichenggang@uniontech.com>  Wed, 22 Apr 2026 15:37:53 +0800
+
 glances (4.3.1+dfsg-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/patches/CVE-2026-30928.patch
+++ b/debian/patches/CVE-2026-30928.patch
@@ -1,0 +1,88 @@
+From 5d3de603e63f21b0fd6aa2b9da0301f757c33e39 Mon Sep 17 00:00:00 2001
+From: nicolargo <nicolashennion@gmail.com>
+Date: Sat, 7 Mar 2026 09:29:31 +0100
+Subject: [PATCH] Unauthenticated Configuration Secrets Exposure
+
+---
+ glances/config.py                      | 29 ++++++++++++++++++++++++++
+ glances/outputs/glances_restful_api.py |  6 +++---
+ 2 files changed, 32 insertions(+), 3 deletions(-)
+
+diff --git a/glances/config.py b/glances/config.py
+index f89b39326f..30ea0fc491 100644
+--- a/glances/config.py
++++ b/glances/config.py
+@@ -17,6 +17,19 @@
+ from glances.globals import BSD, LINUX, MACOS, SUNOS, WINDOWS, ConfigParser, NoOptionError, NoSectionError, system_exec
+ from glances.logger import logger
+ 
++# Sections entirely blocked from the secure view
++_SECURE_BLOCKED_SECTIONS = frozenset(
++    {
++        "passwords",
++    }
++)
++
++# Key name patterns redacted in any section
++_SECURE_SENSITIVE_KEY_RE = re.compile(
++    r"password|token|secret|api_key|apikey|ssl_keyfile",
++    re.IGNORECASE,
++)
++
+ 
+ def user_config_dir():
+     r"""Return a list of per-user config dir (full path).
+@@ -286,6 +299,22 @@ def as_dict(self):
+                 dictionary[section][option] = self.parser.get(section, option)
+         return dictionary
+ 
++    def as_dict_secure(self):
++        """Return a sanitised copy of the configuration dict.
++
++        Intended for unauthenticated API access.
++        - Blocked sections are omitted entirely.
++        - Sensitive keys in remaining sections are replaced by '********'.
++        """
++        sanitized = {}
++        for section, options in self.as_dict().items():
++            if section in _SECURE_BLOCKED_SECTIONS:
++                continue
++            sanitized[section] = {
++                key: "********" if _SECURE_SENSITIVE_KEY_RE.search(key) else value for key, value in options.items()
++            }
++        return sanitized
++
+     def sections(self):
+         """Return a list of all sections."""
+         return self.parser.sections()
+diff --git a/glances/outputs/glances_restful_api.py b/glances/outputs/glances_restful_api.py
+index 1d551b6400..95dc56e640 100644
+--- a/glances/outputs/glances_restful_api.py
++++ b/glances/outputs/glances_restful_api.py
+@@ -1160,7 +1160,7 @@ def _api_config(self):
+         """
+         try:
+             # Get the RAW value of the config' dict
+-            args_json = self.config.as_dict()
++            args_json = self.config.as_dict() if self.args.password else self.config.as_dict_secure()
+         except Exception as e:
+             raise HTTPException(status.HTTP_404_NOT_FOUND, f"Cannot get config ({str(e)})")
+         else:
+@@ -1174,7 +1174,7 @@ def _api_config_section(self, section: str):
+         HTTP/400 if item is not found
+         HTTP/404 if others error
+         """
+-        config_dict = self.config.as_dict()
++        config_dict = self.config.as_dict() if self.args.password else self.config.as_dict_secure()
+         if section not in config_dict:
+             raise HTTPException(status.HTTP_400_BAD_REQUEST, f"Unknown configuration item {section}")
+ 
+@@ -1194,7 +1194,7 @@ def _api_config_section_item(self, section: str, item: str):
+         HTTP/400 if item is not found
+         HTTP/404 if others error
+         """
+-        config_dict = self.config.as_dict()
++        config_dict = self.config.as_dict() if self.args.password else self.config.as_dict_secure()
+         if section not in config_dict:
+             raise HTTPException(status.HTTP_400_BAD_REQUEST, f"Unknown configuration item {section}")
+ 

--- a/debian/patches/CVE-2026-32596.patch
+++ b/debian/patches/CVE-2026-32596.patch
@@ -1,0 +1,38 @@
+From 5bef9eb8f42bec254735ef9631b8dad221bae9f7 Mon Sep 17 00:00:00 2001
+From: lichenggang <lichenggang@uniontech.com>
+Date: Wed, 22 Apr 2026 15:58:29 +0800
+Subject: [PATCH 1/7] cve-32596
+
+---
+ glances/outputs/glances_restful_api.py | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/glances/outputs/glances_restful_api.py b/glances/outputs/glances_restful_api.py
+index d648c5f..7c23a28 100644
+--- a/glances/outputs/glances_restful_api.py
++++ b/glances/outputs/glances_restful_api.py
+@@ -291,6 +291,21 @@ class GlancesRestfulApi:
+         else:
+             logger.info('The WebUI is disable (--disable-webui)')
+ 
++        # Security warning if no authentication is configured
++        if not self.args.password:
++            is_localhost = self.args.bind_address in ('127.0.0.1', 'localhost', '::1')
++            warn_lines = [
++                "WARNING: Glances web server is running WITHOUT authentication.",
++            ]
++            if is_localhost:
++                warn_lines.append("         Use --password to enable authentication.")
++            else:
++                warn_lines.append("         Any client on the network can access system information.")
++                warn_lines.append("         Use --password to enable authentication or")
++                warn_lines.append("         --bind 127.0.0.1 to restrict access to localhost.")
++            print('\n'.join(warn_lines) + '\n')
++            logger.warning("Glances web server is running without authentication")
++
+         # Restful API
+         bindmsg = f'Glances RESTful API Server started on {self.bind_url}api/{self.API_VERSION}'
+         logger.info(bindmsg)
+-- 
+2.51.0
+

--- a/debian/patches/CVE-2026-32608.patch
+++ b/debian/patches/CVE-2026-32608.patch
@@ -1,0 +1,59 @@
+From 8efb791d889e5d159a1f3490c9a22d11e91324be Mon Sep 17 00:00:00 2001
+From: lichenggang <lichenggang@uniontech.com>
+Date: Wed, 22 Apr 2026 15:59:52 +0800
+Subject: [PATCH 2/7] cve-32608
+
+---
+ glances/actions.py | 29 ++++++++++++++++++++++++++++-
+ 1 file changed, 28 insertions(+), 1 deletion(-)
+
+diff --git a/glances/actions.py b/glances/actions.py
+index 5ea247b..dbb5e93 100644
+--- a/glances/actions.py
++++ b/glances/actions.py
+@@ -20,6 +20,31 @@ except ImportError:
+ else:
+     chevron_tag = True
+ 
++# Characters that secure_popen interprets as shell operators.
++# Mustache-rendered values must not contain these to prevent command injection.
++_SHELL_OPERATORS = ('&&', '|', '>>', '>')
++
++
++def _sanitize_mustache_dict(mustache_dict):
++    """Return a copy of mustache_dict with shell operators replaced by spaces.
++
++    This prevents command injection when user-controllable data (process names,
++    container names, mount points, etc.) is rendered into action command lines
++    via Mustache templates.
++    """
++    if not mustache_dict:
++        return mustache_dict
++
++    safe = {}
++    for k, v in mustache_dict.items():
++        if isinstance(v, str):
++            for op in _SHELL_OPERATORS:
++                v = v.replace(op, ' ')
++            safe[k] = v
++        else:
++            safe[k] = v
++    return safe
++
+ 
+ class GlancesActions:
+     """This class manage action if an alert is reached."""
+@@ -75,7 +100,9 @@ class GlancesActions:
+         for cmd in commands:
+             # Replace {{arg}} by the dict one (Thk to {Mustache})
+             if chevron_tag:
+-                cmd_full = chevron.render(cmd, mustache_dict)
++                # Sanitize mustache values to prevent shell operator injection
++                safe_dict = _sanitize_mustache_dict(mustache_dict)
++                cmd_full = chevron.render(cmd, safe_dict)
+             else:
+                 cmd_full = cmd
+             # Execute the action
+-- 
+2.51.0
+

--- a/debian/patches/CVE-2026-32609.patch
+++ b/debian/patches/CVE-2026-32609.patch
@@ -1,0 +1,77 @@
+From 16f6caf457b8bba7cb2531a85e9171330d5463d4 Mon Sep 17 00:00:00 2001
+From: nicolargo <nicolashennion@gmail.com>
+Date: Sat, 14 Mar 2026 14:11:18 +0100
+Subject: [PATCH] Incomplete Secrets Redaction: /api/v4/args Endpoint Leaks
+ Password Hash and SNMP Credentials - Correct CVE-2026-32609
+
+---
+ glances/outputs/glances_restful_api.py | 42 +++++++++++++++++++++-----
+ 1 file changed, 34 insertions(+), 8 deletions(-)
+
+diff --git a/glances/outputs/glances_restful_api.py b/glances/outputs/glances_restful_api.py
+index 49a617a7e9..b81e4122df 100644
+--- a/glances/outputs/glances_restful_api.py
++++ b/glances/outputs/glances_restful_api.py
+@@ -1267,6 +1267,38 @@ def _api_config_section_item(self, section: str, item: str):
+ 
+         return GlancesJSONResponse(ret_item)
+ 
++    # Args keys that must always be redacted (even for authenticated users)
++    _ALWAYS_REDACTED_ARGS = frozenset({'password'})
++
++    # Args keys redacted when no authentication is configured
++    _SENSITIVE_ARGS = frozenset(
++        {
++            'password',
++            'snmp_community',
++            'snmp_user',
++            'snmp_auth',
++            'conf_file',
++            'username',
++        }
++    )
++
++    def _sanitize_args(self):
++        """Return a sanitized copy of self.args as a dict.
++
++        - password hash is always redacted (even for authenticated users)
++        - other sensitive fields are redacted when no authentication is configured
++        """
++        args_json = vars(self.args).copy()
++        if not self.args.password:
++            for key in self._SENSITIVE_ARGS:
++                if key in args_json:
++                    args_json[key] = '********'
++        else:
++            for key in self._ALWAYS_REDACTED_ARGS:
++                if key in args_json and args_json[key]:
++                    args_json[key] = '********'
++        return args_json
++
+     def _api_args(self):
+         """Glances API RESTful implementation.
+ 
+@@ -1275,10 +1307,7 @@ def _api_args(self):
+         HTTP/404 if others error
+         """
+         try:
+-            # Get the RAW value of the args' dict
+-            # Use vars to convert namespace to dict
+-            # Source: https://docs.python.org/%s/library/functions.html#vars
+-            args_json = vars(self.args)
++            args_json = self._sanitize_args()
+         except Exception as e:
+             raise HTTPException(status.HTTP_404_NOT_FOUND, f"Cannot get args ({str(e)})")
+ 
+@@ -1296,10 +1325,7 @@ def _api_args_item(self, item: str):
+             raise HTTPException(status.HTTP_400_BAD_REQUEST, f"Unknown argument item {item}")
+ 
+         try:
+-            # Get the RAW value of the args' dict
+-            # Use vars to convert namespace to dict
+-            # Source: https://docs.python.org/%s/library/functions.html#vars
+-            args_json = vars(self.args)[item]
++            args_json = self._sanitize_args()[item]
+         except Exception as e:
+             raise HTTPException(status.HTTP_404_NOT_FOUND, f"Cannot get args item ({str(e)})")
+ 

--- a/debian/patches/CVE-2026-32610.patch
+++ b/debian/patches/CVE-2026-32610.patch
@@ -1,0 +1,42 @@
+From 5daa7ab89eda6e1b1c8efa8f882e7e9036b79d31 Mon Sep 17 00:00:00 2001
+From: lichenggang <lichenggang@uniontech.com>
+Date: Wed, 22 Apr 2026 16:00:50 +0800
+Subject: [PATCH 3/7] cve-32610
+
+---
+ glances/outputs/glances_restful_api.py | 16 ++++++++++++++--
+ 1 file changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/glances/outputs/glances_restful_api.py b/glances/outputs/glances_restful_api.py
+index 7c23a28..279c44c 100644
+--- a/glances/outputs/glances_restful_api.py
++++ b/glances/outputs/glances_restful_api.py
+@@ -143,11 +143,23 @@ class GlancesRestfulApi:
+ 
+         # FastAPI Enable CORS
+         # https://fastapi.tiangolo.com/tutorial/cors/
++        cors_origins = config.get_list_value('outputs', 'cors_origins', default=["*"])
++        cors_credentials = config.get_bool_value('outputs', 'cors_credentials', default=False)
++
++        # Reject the insecure wildcard + credentials combination,
++        # even if the user explicitly sets cors_credentials=True in their config.
++        if cors_origins == ["*"] and cors_credentials:
++            logger.warning(
++                "CORS: allow_origins=['*'] combined with allow_credentials=True is insecure. "
++                "Disabling credentials. Set explicit cors_origins to enable credentialed requests."
++            )
++            cors_credentials = False
++
+         self._app.add_middleware(
+             CORSMiddleware,
+             # Related to https://github.com/nicolargo/glances/issues/2812
+-            allow_origins=config.get_list_value('outputs', 'cors_origins', default=["*"]),
+-            allow_credentials=config.get_bool_value('outputs', 'cors_credentials', default=True),
++            allow_origins=cors_origins,
++            allow_credentials=cors_credentials,
+             allow_methods=config.get_list_value('outputs', 'cors_methods', default=["*"]),
+             allow_headers=config.get_list_value('outputs', 'cors_headers', default=["*"]),
+         )
+-- 
+2.51.0
+

--- a/debian/patches/CVE-2026-32632.patch
+++ b/debian/patches/CVE-2026-32632.patch
@@ -1,0 +1,67 @@
+From 3d150eafa426671ebe51777266eb939eecd65b32 Mon Sep 17 00:00:00 2001
+From: lichenggang <lichenggang@uniontech.com>
+Date: Wed, 22 Apr 2026 16:05:36 +0800
+Subject: [PATCH 4/7] CVE-2026-32632: DNS rebinding protection via
+ TrustedHostMiddleware
+
+---
+ glances/outputs/glances_restful_api.py | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/glances/outputs/glances_restful_api.py b/glances/outputs/glances_restful_api.py
+index 279c44c..458572e 100644
+--- a/glances/outputs/glances_restful_api.py
++++ b/glances/outputs/glances_restful_api.py
+@@ -164,6 +164,15 @@ class GlancesRestfulApi:
+             allow_headers=config.get_list_value('outputs', 'cors_headers', default=["*"]),
+         )
+ 
++        # FastAPI Enable DNS rebinding protection via Host header validation
++        # When webui_allowed_hosts is configured, requests with a Host header
++        # not in the allowlist are rejected with 400 Bad Request.
++        if self.webui_allowed_hosts:
++            from starlette.middleware.trustedhost import TrustedHostMiddleware
++
++            self._app.add_middleware(TrustedHostMiddleware, allowed_hosts=self.webui_allowed_hosts)
++            logger.info(f"TrustedHostMiddleware enabled (allowed hosts: {self.webui_allowed_hosts})")
++
+         # FastAPI Enable GZIP compression
+         # https://fastapi.tiangolo.com/advanced/middleware/
+         self._app.add_middleware(GZipMiddleware, minimum_size=1000)
+@@ -183,6 +192,7 @@ class GlancesRestfulApi:
+         """Load the outputs section of the configuration file."""
+         # Limit the number of processes to display in the WebUI
+         self.url_prefix = ''
++        self.webui_allowed_hosts = None
+         if config is not None and config.has_section('outputs'):
+             # Max process to display in the WebUI
+             n = config.get_value('outputs', 'max_processes_display', default=None)
+@@ -192,6 +202,8 @@ class GlancesRestfulApi:
+             if self.url_prefix != '':
+                 self.url_prefix = self.url_prefix.rstrip('/')
+             logger.debug(f'URL prefix: {self.url_prefix}')
++            # DNS rebinding protection for the REST API / WebUI
++            self.webui_allowed_hosts = config.get_list_value('outputs', 'webui_allowed_hosts', default=None)
+ 
+     def __update_stats(self):
+         # Never update more than 1 time per cached_time
+@@ -318,6 +330,16 @@ class GlancesRestfulApi:
+             print('\n'.join(warn_lines) + '\n')
+             logger.warning("Glances web server is running without authentication")
+ 
++        if not self.webui_allowed_hosts:
++            warn_lines = [
++                "WARNING: Glances web server is running without Host header validation.",
++                "         DNS rebinding attacks may allow untrusted pages to read the REST API.",
++                "         Set webui_allowed_hosts in glances.conf [outputs] to restrict access:",
++                "           webui_allowed_hosts=localhost,127.0.0.1,<your-hostname>",
++            ]
++            print('\n'.join(warn_lines) + '\n')
++            logger.warning("Glances web server is running without Host header validation (DNS rebinding protection)")
++
+         # Restful API
+         bindmsg = f'Glances RESTful API Server started on {self.bind_url}api/{self.API_VERSION}'
+         logger.info(bindmsg)
+-- 
+2.51.0
+

--- a/debian/patches/CVE-2026-32633.patch
+++ b/debian/patches/CVE-2026-32633.patch
@@ -1,0 +1,42 @@
+From 73674e5ef4ecfdc87d2d348f2e4cf2ebc6e9dd52 Mon Sep 17 00:00:00 2001
+From: lichenggang <lichenggang@uniontech.com>
+Date: Wed, 22 Apr 2026 16:31:14 +0800
+Subject: [PATCH] CVE-2026-32633: Sanitize serverslist API to remove
+ credentials
+
+---
+ glances/outputs/glances_restful_api.py | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/glances/outputs/glances_restful_api.py b/glances/outputs/glances_restful_api.py
+index 458572e..087acd5 100644
+--- a/glances/outputs/glances_restful_api.py
++++ b/glances/outputs/glances_restful_api.py
+@@ -491,6 +491,14 @@ class GlancesRestfulApi:
+ 
+         return GlancesJSONResponse(plist)
+ 
++    @staticmethod
++    def _sanitize_server(server):
++        """Return a copy of the server dict without credential-bearing fields."""
++        safe = dict(server)
++        safe.pop('password', None)
++        safe.pop('uri', None)
++        return safe
++
+     def _api_servers_list(self):
+         """Glances API RESTful implementation.
+ 
+@@ -500,7 +508,8 @@ class GlancesRestfulApi:
+         # Update the servers list (and the stats for all the servers)
+         self.__update_servers_list()
+ 
+-        return GlancesJSONResponse(self.servers_list.get_servers_list() if self.servers_list else [])
++        servers = self.servers_list.get_servers_list() if self.servers_list else []
++        return GlancesJSONResponse([self._sanitize_server(s) for s in servers])
+ 
+     def _api_all(self):
+         """Glances API RESTful implementation.
+-- 
+2.51.0
+

--- a/debian/patches/CVE-2026-32634.patch
+++ b/debian/patches/CVE-2026-32634.patch
@@ -1,0 +1,79 @@
+From 3e18eb6b427769d017b600f38d42588016a3e066 Mon Sep 17 00:00:00 2001
+From: lichenggang <lichenggang@uniontech.com>
+Date: Wed, 22 Apr 2026 16:07:42 +0800
+Subject: [PATCH 5/7] CVE-2026-32634: Central Browser autodiscovery credential
+ leak fix
+
+---
+ glances/client_browser.py |  4 +++-
+ glances/servers_list.py   | 31 +++++++++++++++++++++++++++----
+ 2 files changed, 30 insertions(+), 5 deletions(-)
+
+diff --git a/glances/client_browser.py b/glances/client_browser.py
+index a6bba83..6f34a56 100644
+--- a/glances/client_browser.py
++++ b/glances/client_browser.py
+@@ -52,7 +52,9 @@ class GlancesClientBrowser:
+         # A password is needed to access to the server's stats
+         if server['password'] is None:
+             # First of all, check if a password is available in the [passwords] section
+-            clear_password = self.servers_list.password.get_password(server['name'])
++            # Use _get_preconfigured_password to avoid leaking saved/default credentials
++            # to untrusted dynamic (Zeroconf) server entries
++            clear_password = self.servers_list._get_preconfigured_password(server)
+             if (
+                 clear_password is None
+                 or self.servers_list.get_servers_list()[self.screen.active_server]['status'] == 'PROTECTED'
+diff --git a/glances/servers_list.py b/glances/servers_list.py
+index b208543..2eeb31d 100644
+--- a/glances/servers_list.py
++++ b/glances/servers_list.py
+@@ -116,18 +116,41 @@ class GlancesServersList:
+                 self.threads_list[key] = thread
+                 thread.start()
+ 
++    @staticmethod
++    def _get_connect_host(server):
++        """Return the host to use for connecting to the server.
++
++        For dynamic (Zeroconf) servers, use the discovered IP address
++        instead of the untrusted advertised name.
++        """
++        if server.get('type') == 'DYNAMIC':
++            return server['ip']
++        return server['name']
++
++    def _get_preconfigured_password(self, server):
++        """Return the preconfigured password for the server.
++
++        Dynamic (Zeroconf) entries are untrusted and should not inherit
++        saved or default credentials to prevent credential exfiltration
++        via fake Zeroconf services.
++        """
++        if server.get('type') == 'DYNAMIC':
++            return None
++        return self.password.get_password(server['name'])
++
+     def get_uri(self, server):
+         """Return the URI for the given server dict."""
++        host = self._get_connect_host(server)
+         # Select the connection mode (with or without password)
+         if server['password'] != "":
+             if server['status'] == 'PROTECTED':
+-                # Try with the preconfigure password (only if status is PROTECTED)
+-                clear_password = self.password.get_password(server['name'])
++                # Try with the preconfigured password (only if status is PROTECTED)
++                clear_password = self._get_preconfigured_password(server)
+                 if clear_password is not None:
+                     server['password'] = self.password.get_hash(clear_password)
+-            uri = 'http://{}:{}@{}:{}'.format(server['username'], server['password'], server['ip'], server['port'])
++            uri = 'http://{}:{}@{}:{}'.format(server['username'], server['password'], host, server['port'])
+         else:
+-            uri = 'http://{}:{}'.format(server['ip'], server['port'])
++            uri = 'http://{}:{}'.format(host, server['port'])
+         return uri
+ 
+     def set_in_selected(self, selected, key, value):
+-- 
+2.51.0
+

--- a/debian/patches/CVE-2026-33533.patch
+++ b/debian/patches/CVE-2026-33533.patch
@@ -1,0 +1,64 @@
+From fa23c6f9d77018c2fd6b41f7be789e610dc4e7e4 Mon Sep 17 00:00:00 2001
+From: lichenggang <lichenggang@uniontech.com>
+Date: Wed, 22 Apr 2026 16:08:57 +0800
+Subject: [PATCH 6/7] CVE-2026-33533: XML-RPC server configurable CORS origin
+
+---
+ glances/server.py | 27 ++++++++++++++++++++++++++-
+ 1 file changed, 26 insertions(+), 1 deletion(-)
+
+diff --git a/glances/server.py b/glances/server.py
+index 8946fa8..a63ed7d 100644
+--- a/glances/server.py
++++ b/glances/server.py
+@@ -39,7 +39,9 @@ class GlancesXMLRPCHandler(xmlrpc.xmlrpc_server.SimpleXMLRPCRequestHandler):
+ 
+     def send_my_headers(self):
+         # Specific header is here (solved the issue #227)
+-        self.send_header("Access-Control-Allow-Origin", "*")
++        # Use configurable CORS origins (default: *) read from the server instance
++        cors_origin = getattr(self.server, 'cors_origin', '*')
++        self.send_header("Access-Control-Allow-Origin", cors_origin)
+ 
+     def authenticate(self, headers):
+         # auth = headers.get('Authorization')
+@@ -98,6 +100,18 @@ class GlancesXMLRPCServer(xmlrpc.xmlrpc_server.SimpleXMLRPCServer):
+         self.bind_address = bind_address
+         self.bind_port = bind_port
+         self.config = config
++
++        # Read CORS origins from config — same key as the REST API
++        # Default: "*" for backward compatibility
++        if config is not None:
++            cors_origins = config.get_list_value('outputs', 'cors_origins', default=["*"])
++        else:
++            cors_origins = ["*"]
++        # For the XML-RPC handler we emit a single Access-Control-Allow-Origin
++        # header. If the config lists a single explicit origin, use it;
++        # otherwise fall back to "*".
++        self.cors_origin = cors_origins[0] if len(cors_origins) == 1 else "*"
++
+         try:
+             self.address_family = socket.getaddrinfo(bind_address, bind_port)[0][0]
+         except OSError as e:
+@@ -195,6 +209,17 @@ class GlancesServer:
+         self.server.user_dict = {}
+         self.server.isAuth = False
+ 
++        # Warn if running unauthenticated with wildcard CORS
++        if args.password == "" and self.server.cors_origin == "*":
++            print(
++                "WARNING: XML-RPC server is running without authentication and with CORS Allow-Origin: *.\n"
++                "         Mitigations: set a password (-P/--password) and/or restrict\n"
++                "         cors_origins in glances.conf [outputs] section."
++            )
++            logger.warning(
++                "XML-RPC server is running without authentication and with CORS Access-Control-Allow-Origin: *. "
++            )
++
+         # Register functions
+         self.server.register_introspection_functions()
+         self.server.register_instance(GlancesInstance(config, args))
+-- 
+2.51.0
+

--- a/debian/patches/CVE-2026-33641.patch
+++ b/debian/patches/CVE-2026-33641.patch
@@ -1,0 +1,98 @@
+From e68fb8259d05e6f9d968e2808b3395fd82430d0f Mon Sep 17 00:00:00 2001
+From: lichenggang <lichenggang@uniontech.com>
+Date: Wed, 22 Apr 2026 16:11:29 +0800
+Subject: [PATCH 7/7] CVE-2026-33641: Disable config backtick command execution
+
+---
+ glances/config.py  | 10 ++++++++--
+ glances/globals.py | 12 +++++++++---
+ glances/main.py    | 10 +++++++++-
+ 3 files changed, 26 insertions(+), 6 deletions(-)
+
+diff --git a/glances/config.py b/glances/config.py
+index 30ea0fc..e789d0d 100644
+--- a/glances/config.py
++++ b/glances/config.py
+@@ -128,11 +128,12 @@ class Config:
+     :type config_dir: str or None
+     """
+ 
+-    def __init__(self, config_dir=None):
++    def __init__(self, config_dir=None, disable_config_exec=False):
+         self.config_dir = config_dir
+         self.config_filename = 'glances.conf'
+         self._loaded_config_file = None
+         self._config_file_paths = self.config_file_paths()
++        self._disable_config_exec = disable_config_exec
+ 
+         # Re pattern for optimize research of `foo`
+         self.re_pattern = re.compile(r'(\`.+?\`)')
+@@ -362,7 +363,12 @@ class Config:
+             try:
+                 match = self.re_pattern.findall(ret)
+                 for m in match:
+-                    ret = ret.replace(m, system_exec(m[1:-1]))
++                    command = m[1:-1]
++                    if self._disable_config_exec:
++                        logger.warning(f"Config exec disabled: skipping command `{command}` in [{section}] {option}")
++                    else:
++                        logger.warning(f"Executing config command `{command}` for [{section}] {option}")
++                        ret = ret.replace(m, system_exec(command))
+             except TypeError:
+                 pass
+         return ret
+diff --git a/glances/globals.py b/glances/globals.py
+index 7bd291c..393c35c 100644
+--- a/glances/globals.py
++++ b/glances/globals.py
+@@ -159,10 +159,16 @@ def nativestr(s, errors='replace'):
+     return s.decode('utf-8', errors=errors)
+ 
+ 
+-def system_exec(command):
+-    """Execute a system command and return the result as a str"""
++def system_exec(command, timeout=5):
++    """Execute a system command and return the result as a str.
++
++    A hard timeout (default 5 s) prevents blocking commands from hanging
++    the process indefinitely.
++    """
+     try:
+-        res = subprocess.run(command.split(' '), stdout=subprocess.PIPE).stdout.decode('utf-8')
++        res = subprocess.run(command.split(' '), stdout=subprocess.PIPE, timeout=timeout).stdout.decode('utf-8')
++    except subprocess.TimeoutExpired:
++        res = f'ERROR: command `{command}` timed out after {timeout}s'
+     except Exception as e:
+         res = f'ERROR: {e}'
+     return res.rstrip()
+diff --git a/glances/main.py b/glances/main.py
+index e408816..04e2aa0 100644
+--- a/glances/main.py
++++ b/glances/main.py
+@@ -108,7 +108,7 @@ Examples of use:
+         # Load the configuration file, if it exists
+         # This function should be called after the parse_args
+         # because the configuration file path can be defined
+-        self.config = Config(self.args.conf_file)
++        self.config = Config(config_dir=self.args.conf_file, disable_config_exec=self.args.disable_config_exec)
+ 
+         # Init Glances debug mode
+         self.init_debug(self.args)
+@@ -602,6 +602,14 @@ Examples of use:
+             default=False,
+             help='hide public information (like public IP)',
+         )
++        # Security options
++        parser.add_argument(
++            '--disable-config-exec',
++            action='store_true',
++            default=False,
++            dest='disable_config_exec',
++            help='disable backtick command execution in configuration values (recommended for system services)',
++        )
+         # Globals options
+         parser.add_argument(
+             '--disable-check-update',
+-- 
+2.51.0
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,3 +4,13 @@
 003_not_install_static_dir.patch
 004_disable-pypi.patch
 006_indicate_user_webserver_static_files_not_included.patch
+CVE-2026-30928.patch
+CVE-2026-32596.patch
+CVE-2026-32608.patch
+CVE-2026-32609.patch
+CVE-2026-32610.patch
+CVE-2026-32632.patch
+CVE-2026-32633.patch
+CVE-2026-32634.patch
+CVE-2026-33533.patch
+CVE-2026-33641.patch


### PR DESCRIPTION
Backport upstream fixes for the following CVEs:
- CVE-2026-30928: Unauthenticated Configuration Secrets Exposure https://github.com/nicolargo/glances/commit/306a7136154ba5c1531489c99f8306d84eae37da
- CVE-2026-32609: Incomplete Secrets Redaction in /api/4/args endpoint https://github.com/nicolargo/glances/commit/2c5d3a8f12b2a1eec708c58d22d7a1d62bdf5fa1
- CVE-2026-32596: Unauthenticated Web Server Exposure https://github.com/nicolargo/glances/commit/fb0263af0c2d06f87667eb804bc8e147f243aa5c
- CVE-2026-32608: Mustache Template Command Injection https://github.com/nicolargo/glances/commit/5680a5da4afdf762fd44ced1f8160fb6d5c5dd16
- CVE-2026-32610: CORS Wildcard with Credentials https://github.com/nicolargo/glances/commit/4465169b71d93991f1e49740fe02428291099832
- CVE-2026-32632: DNS Rebinding Protection https://github.com/nicolargo/glances/commit/5850c564ee10804fdf884823b9c210eb954dd1f9
- CVE-2026-32633: Serverslist API Exposes Downstream Credentials https://github.com/nicolargo/glances/commit/879ef8688ffa1630839549751d3c7ef9961d361e
- CVE-2026-32634: Central Browser Credential Leak https://github.com/nicolargo/glances/commit/61d38eec521703e41e4933d18d5a5ef6f854abd5
- CVE-2026-33533: XML-RPC CORS Information Disclosure https://github.com/nicolargo/glances/commit/dcb39c3f12b2a1eec708c58d22d7a1d62bdf5fa1
- CVE-2026-33641: Config Backtick Command Execution https://github.com/nicolargo/glances/commit/358d76a225fc21a9f95d2c4d7e46fafe64a644c6

Log: 回溯上游安全修复，修复多个 glances CVE 漏洞

回溯上游提交以修复以下 CVE：
- CVE-2026-30928：未认证配置信息泄露
- CVE-2026-32609：/api/4/args 端点密钥脱敏不完整
- CVE-2026-32596：未认证 Web 服务器暴露
- CVE-2026-32608：Mustache 模板命令注入
- CVE-2026-32610：CORS 通配符与凭据组合漏洞
- CVE-2026-32632：DNS Rebinding 防护缺失
- CVE-2026-32633：Serverslist API 泄露下游服务器凭据
- CVE-2026-32634：Central Browser 凭据泄露
- CVE-2026-33533：XML-RPC CORS 信息泄露
- CVE-2026-33641：配置反引号命令执行